### PR TITLE
SiteCreate - Allow more flexible workflows

### DIFF
--- a/src/Joomlatools/Console/Command/SiteCreate.php
+++ b/src/Joomlatools/Console/Command/SiteCreate.php
@@ -71,9 +71,18 @@ class SiteCreate extends SiteAbstract
     protected $versions;
 
     /**
+     * @var bool
+     */
+    protected $is_download_enabled;
+
+    /**
+     * @var bool
+     */
+    protected $is_install_enabled;
+
+    /**
      *
      */
-
     protected function configure()
     {
         parent::configure();
@@ -117,6 +126,20 @@ class SiteCreate extends SiteAbstract
                 'Directory where your custom projects reside',
                 sprintf('%s/Projects', trim(`echo ~`))
             )
+            ->addOption(
+                'download',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Whether to download fresh code (yes|no). If Joomla is already downloaded, then use "no".',
+                'yes'
+            )
+            ->addOption(
+                'install',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Whether to setup database and config files (yes|no)',
+                'yes'
+            )
             ;
     }
 
@@ -132,6 +155,9 @@ class SiteCreate extends SiteAbstract
 
         $this->setVersion($input->getOption('joomla'));
 
+        $this->is_download_enabled = $input->getOption('download') === 'yes' && !empty($this->version);
+        $this->is_install_enabled = $input->getOption('install') === 'yes';
+
         $this->symlink = $input->getOption('symlink');
         if (is_string($this->symlink)) {
             $this->symlink = explode(',', $this->symlink);
@@ -142,13 +168,30 @@ class SiteCreate extends SiteAbstract
         $this->source_db = $this->target_dir.'/installation/sql/mysql/joomla.sql';
 
         $this->check($input, $output);
-        $this->createFolder($input, $output);
-        $this->createDatabase($input, $output);
-        $this->modifyConfiguration($input, $output);
-        $this->addVirtualHost($input, $output);
-        $this->symlinkProjects($input, $output);
-        $this->installExtensions($input, $output);
-        $this->enableWebInstaller($input, $output);
+
+        if ($this->is_download_enabled)
+        {
+            $this->createFolder($input, $output);
+        }
+        else
+        {
+            $output->writeln("<info>Skipped download</info>");
+            $this->restoreInstallationFolder();
+        }
+
+        if ($this->is_install_enabled)
+        {
+            $this->createDatabase($input, $output);
+            $this->modifyConfiguration($input, $output);
+            $this->addVirtualHost($input, $output);
+            $this->symlinkProjects($input, $output);
+            $this->installExtensions($input, $output);
+            $this->enableWebInstaller($input, $output);
+        }
+        else
+        {
+            $output->writeln("<info>Skipped installation</info>");
+        }
 
         if ($this->version)
         {
@@ -159,23 +202,33 @@ class SiteCreate extends SiteAbstract
 
     public function check(InputInterface $input, OutputInterface $output)
     {
-        if (file_exists($this->target_dir)) {
+        if ($this->is_download_enabled && file_exists($this->target_dir)) {
             throw new \RuntimeException(sprintf('A site with name %s already exists', $this->site));
         }
 
-        if ($this->version)
+        if (!$this->is_download_enabled)
+        {
+            if (!is_dir($this->target_dir . DIRECTORY_SEPARATOR . 'installation') && !is_dir($this->target_dir . DIRECTORY_SEPARATOR . '_installation')) {
+                throw new \RuntimeException(sprintf("Target directory %s is missing or incorrect. (Failed to locate installer.)", $this->target_dir));
+            }
+        }
+
+        if ($this->is_install_enabled)
         {
             if ($this->checkDatabaseExists($this->target_db) && $this->checkDatabasePopulated($this->target_db, self::DB_PREFIX)) {
                 throw new \RuntimeException(sprintf('A database with name %s is already populated', $this->target_db));
             }
+        }
 
+        if ($this->is_download_enabled)
+        {
             $this->source_tarball = $this->getTarball($this->version, $output);
             if(!file_exists($this->source_tarball)) {
                 throw new \RuntimeException(sprintf('File %s does not exist', $this->source_tarball));
             }
         }
 
-        if ($this->version && $this->sample_data)
+        if ($this->is_install_enabled && $this->sample_data)
         {
             if (!in_array($this->sample_data, array('default', 'blog', 'brochure', 'testing', 'learn'))) {
                 throw new \RuntimeException(sprintf('Unknown sample data "%s"', $this->sample_data));
@@ -196,7 +249,9 @@ class SiteCreate extends SiteAbstract
      */
     public function checkDatabaseExists($db_name)
     {
-        $result = $this->executeMysqlCli(sprintf('SHOW DATABASES LIKE "%s"', $db_name));
+        $result = $this->executeMysqlCli(
+            sprintf('SHOW DATABASES LIKE "%s"', $db_name)
+        );
         return !empty($result);
     }
 
@@ -205,8 +260,10 @@ class SiteCreate extends SiteAbstract
      * @param string $db_prefix
      * @return bool
      */
-    function checkDatabasePopulated($db_name, $db_prefix = self::DB_PREFIX) {
-        $result = $this->executeMysqlCli(sprintf('CONNECT %s; SHOW TABLES LIKE "%s"', $db_name, $db_prefix . '%'));
+    function checkDatabasePopulated($db_name, $db_prefix) {
+        $result = $this->executeMysqlCli(
+            sprintf('CONNECT %s; SHOW TABLES LIKE "%s"', $db_name, $db_prefix . '%')
+        );
         return !empty($result);
     }
 
@@ -221,6 +278,12 @@ class SiteCreate extends SiteAbstract
             if ($this->versions->isBranch($this->version)) {
                 unlink($this->source_tarball);
             }
+        }
+    }
+
+    public function restoreInstallationFolder() {
+        if (is_dir($this->target_dir . DIRECTORY_SEPARATOR . '_installation') && !is_dir($this->target_dir . DIRECTORY_SEPARATOR . 'installation')) {
+            `mv $this->target_dir/_installation $this->target_dir/installation`;
         }
     }
 


### PR DESCRIPTION
The site:create command tightly couples the download, installation, DB creation, etc.  This is handy for
quick-starting, but when piecing-together different dev workflows, it's helpful to make these a bit more flexible, e.g.

 * When doing scheduled CI, one checks out the latest code from SCM (git/svn/bzr/whatever) and then performs an installation.
 * When auto-testing PRs from Github (or other types of changesets in other SCMs), one might download the official code, then
   apply a patch, then run the installation.
 * Some site-admins create an aggregated git repo which combines core code plus any extensions.
 * When developing installation logic (for core code or extension code), it's convenient to rerun the installation logic
   with yourlocally-developed code.

(Aside: This is based on my experience developing https://buildkit-ui.civicrm.org/ .  I started out with a similar "create"
command which combined download+install and later refactored to allow them to be run individually.  Notably, both drush
and wp-cli strictly separate the download+install commands.)