### PR TITLE
Add mysql_db_prefix option to allow for changing `sites_` into something...

### DIFF
--- a/src/Joomlatools/Console/Command/SiteAbstract.php
+++ b/src/Joomlatools/Console/Command/SiteAbstract.php
@@ -20,6 +20,7 @@ abstract class SiteAbstract extends Command
 
     protected $target_dir;
     protected $target_db;
+    protected $target_db_prefix = 'sites_';
 
     protected $mysql;
 
@@ -43,6 +44,13 @@ abstract class SiteAbstract extends Command
             "MySQL credentials in the form of user:password",
             'root:root'
         )
+        ->addOption(
+            'mysql_db_prefix',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            "MySQL database prefix (default: sites_)",
+            'sites_'
+        )
         ;
     }
 
@@ -50,8 +58,9 @@ abstract class SiteAbstract extends Command
     {
         $this->site       = $input->getArgument('site');
         $this->www        = $input->getOption('www');
+        $this->target_db_prefix = $input->getOption('mysql_db_prefix');
 
-        $this->target_db  = 'sites_'.$this->site;
+        $this->target_db  = $this->target_db_prefix.$this->site;
         $this->target_dir = $this->www.'/'.$this->site;
 
         $credentials = explode(':', $input->getOption('mysql'), 2);


### PR DESCRIPTION
The current approach of the joomla-console is to create databases with a prefix "sites_". In my own setup, I want to use a different prefix that I can customize, so that multiple users can easily create different sets of databases. This patch simply adds another CLI argument for this.