### PR TITLE
Added allowoverride for .htaccess use

### DIFF
--- a/bin/.files/vhost.conf
+++ b/bin/.files/vhost.conf
@@ -3,6 +3,12 @@
     DocumentRoot %2$s
     ServerName %1$s.dev
     ServerAlias www.%1$s.dev
+ 
+    <Directory /var/www/@%1$s>
+       Options Indexes FollowSymLinks
+       AllowOverride All
+       Require all granted
+    </Directory>
 
     ErrorLog  /var/log/apache2/%1$s.dev-error_log
     CustomLog /var/log/apache2/%1$s.dev-access_log common


### PR DESCRIPTION
We were having issues with SEO links not working for our Joomla installs because our .htaccess was not being read.  I'm not sure if this is the way we should be going about it, but I figured I'd submit it and see.